### PR TITLE
Polishing

### DIFF
--- a/config/config.example.yaml
+++ b/config/config.example.yaml
@@ -63,7 +63,7 @@ jira:
 replies:
   jira:
     default:
-      title: "I found %d issues:"
+      title: "I found %d issue(s):"
       text: list
       parameter: amount
       color: e8e8e8

--- a/readme.md
+++ b/readme.md
@@ -188,7 +188,7 @@ Some are neeeded by default as they are used by commands. The color value `all` 
 replies:
   jira:
     default:
-      title: "I found %d issues:"
+      title: "I found %d issue(s):"
       text: list
       parameter: amount
       color: e8e8e8

--- a/readme.md
+++ b/readme.md
@@ -182,8 +182,8 @@ jira:
 ```
 
 ## Replies
-This part of the configurations allows to create custom reply layouts for any JIRA queries.
-Some are neeeded by default as they are used by commands. The color value `all` and `medium` relates to the bug thresholds which are set separately.
+This part of the configuration allows to create custom reply layouts for any JIRA queries.
+Some are needed by default as they are used by commands. The color value `all` and `medium` relates to the bug thresholds which are set separately.
 ```
 replies:
   jira:


### PR DESCRIPTION
Hi,

if only one new issue is found - which happens quite often - the jira reply title is suboptimal because it says `I found 1 issues`. This PR improves this pragmatically by saying `I found 1 issue(s)`. Alternatively, we could introduce two configs: one for plural, one for singular.

The PR also fixes the wording in the README a bit in the surroundings of the specific example.

Cheers,
Christoph